### PR TITLE
docs: update issue links to use templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Describe the Bug
+
+<!-- Clear description of what went wrong -->
+
+## To Reproduce
+
+Steps to reproduce:
+1. Install package
+2. Import component '...'
+3. Use with props '...'
+4. See error
+
+## Expected Behavior
+
+<!-- What should happen instead? -->
+
+## Actual Behavior
+
+<!-- What actually happens? -->
+
+## Code Sample
+
+```tsx
+// Minimal code that reproduces the issue
+import { Button } from '@markfoster314/marduk';
+
+<Button variant="primary">Click</Button>
+```
+
+## Environment
+
+- **Marduk version:** [e.g. 0.2.0]
+- **React version:** [e.g. 19.0.0]
+- **Browser:** [e.g. Chrome 120]
+- **OS:** [e.g. Windows 11, macOS 14]
+- **Build tool:** [e.g. Vite, Create React App, Next.js]
+
+## Additional Context
+
+<!-- Screenshots, error messages, console logs -->
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,37 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## Feature Description
+
+<!-- What feature would you like to see? -->
+
+## Use Case
+
+<!-- Why do you need this? What problem does it solve? -->
+
+## Proposed Solution
+
+<!-- How do you envision this working? -->
+
+## Example Usage
+
+```tsx
+// How you'd like to use the feature
+<NewComponent prop="value">
+  Content
+</NewComponent>
+```
+
+## Alternatives Considered
+
+<!-- Any workarounds or alternative approaches? -->
+
+## Additional Context
+
+<!-- Mockups, examples from other libraries, etc. -->
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+## Description
+
+<!-- What does this PR do? Link to related issue if applicable -->
+
+Fixes #(issue)
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactor (no functional changes)
+
+## Testing
+
+- [ ] All tests pass locally (`npm test`)
+- [ ] Linting passes (`npm run lint`)
+- [ ] Type checking passes (`npm run type-check`)
+- [ ] Build succeeds (`npm run build`)
+- [ ] Added/updated tests for changes
+
+## Component Checklist (if applicable)
+
+- [ ] Component follows existing patterns
+- [ ] Includes TypeScript types
+- [ ] Has tests with good coverage
+- [ ] Has Storybook story
+- [ ] CSS uses design tokens/variables
+- [ ] Accessibility considered (ARIA, keyboard navigation)
+- [ ] Works in dark mode (if applicable)
+
+## Screenshots (if applicable)
+
+<!-- Add screenshots or gifs of visual changes -->
+
+## Additional Notes
+
+<!-- Anything else reviewers should know? -->
+

--- a/README.md
+++ b/README.md
@@ -254,7 +254,9 @@ const MyButton = ({ isLoading, ...props }: CustomButtonProps) => (
 
 **Contributions are welcome!** Read our [Contributing Guide](./CONTRIBUTING.md) for detailed information about our development process, code standards, and how to submit pull requests.
 
-[Open an issue](https://github.com/markfoster314/marduk/issues) if you find bugs.
+- [Report a bug](https://github.com/markfoster314/marduk/issues/new?template=bug_report.md)
+- [Request a feature](https://github.com/markfoster314/marduk/issues/new?template=feature_request.md)
+- [General discussion](https://github.com/markfoster314/marduk/issues)
 
 ## License
 

--- a/src/components/Box/README.md
+++ b/src/components/Box/README.md
@@ -8,8 +8,6 @@ _"Cool, I only get weekends off."_
 
 Polymorphic layout primitive
 
-Got any ideas for stuff to add? [Open an issue](https://github.com/markfoster314/marduk/issues/new)
-
 ## Basic Usage
 
 ```tsx

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -8,8 +8,6 @@ _"Oh!"_
 
 A flexible, accessible button component
 
-Got any ideas for stuff to add? [Open an issue](https://github.com/markfoster314/marduk/issues/new)
-
 ## Basic Usage
 
 ```tsx

--- a/src/components/Svg/README.md
+++ b/src/components/Svg/README.md
@@ -8,8 +8,6 @@ _"I guess power comes at a price in every world."_
 
 SVG icon component with animations and transformations
 
-Got any ideas for stuff to add? [Open an issue](https://github.com/markfoster314/marduk/issues/new)
-
 ## Basic Usage
 
 ```tsx

--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -8,8 +8,6 @@ _"Mmm."_
 
 Polymorphic text component with preset system
 
-If you have any ideas for things to add to this component feel free to [Open an issue](https://github.com/markfoster314/marduk/issues/new)
-
 ## Basic Usage
 
 ```tsx

--- a/src/components/Title/README.md
+++ b/src/components/Title/README.md
@@ -8,8 +8,6 @@ _"I found you."_
 
 Heading component
 
-If you have any ideas for things to add to this component feel free to [Open an issue](https://github.com/markfoster314/marduk/issues/new)
-
 ## Basic Usage
 
 ```tsx

--- a/src/compositions/Alert/README.md
+++ b/src/compositions/Alert/README.md
@@ -8,8 +8,6 @@ _"It's hard to tell what you could do"_
 
 Contextual feedback messages for user actions and system updates
 
-Got any ideas for stuff to add? [Open an issue](https://github.com/markfoster314/marduk/issues/new)
-
 ## Basic Usage
 
 ```tsx

--- a/src/compositions/LoadingScreen/README.md
+++ b/src/compositions/LoadingScreen/README.md
@@ -8,8 +8,6 @@ _"Okay, let me ask you, are you sure? 'Cause I've seen this once before"_
 
 Full-screen loading overlay
 
-Got any ideas for stuff to add? [Open an issue](https://github.com/markfoster314/marduk/issues/new)
-
 ## Basic Usage
 
 ```tsx

--- a/src/icons/README.md
+++ b/src/icons/README.md
@@ -8,8 +8,6 @@ _"There's no way back"_
 
 Icon library with individual components and a generic loader
 
-Got any ideas for stuff to add? [Open an issue](https://github.com/markfoster314/marduk/issues/new)
-
 ## Basic Usage
 
 ```tsx


### PR DESCRIPTION
## Description

Updates README file to link directly to GitHub issue templates instead of generic issue pages.

Changes:
- Main README now includes specific links for bug reports, feature requests, and discussions
- All 8 component/composition READMEs remove bug reporting section

## Type of Change

- [x] Documentation update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)

## Testing

- [x] All tests pass locally (`npm test`)
- [x] Linting passes (`npm run lint`)
- [x] Type checking passes (`npm run type-check`)
- [x] Build succeeds (`npm run build`)
- [x] Added/updated tests for changes (N/A - docs only)

## Component Checklist (if applicable)

N/A - Documentation changes only

## Screenshots (if applicable)

N/A - Link updates only

