### PR TITLE
docs: Clean up Text component usage in stories

### DIFF
--- a/src/components/Box/Box.stories.tsx
+++ b/src/components/Box/Box.stories.tsx
@@ -15,6 +15,13 @@ const meta: Meta<typeof Box> = {
     },
   },
   argTypes: {
+    children: {
+      control: false,
+      description: "Content to render inside the Box",
+      table: {
+        type: { summary: "ReactNode" },
+      },
+    },
     padding: {
       control: "select",
       options: ["xs", "sm", "md", "lg", "xl", "2xl", "3xl"],
@@ -64,7 +71,7 @@ type Story = StoryObj<typeof Box>;
 export const Default: Story = {
   args: {
     padding: "md",
-    children: "Box content",
+    children: <Text>Box content</Text>,
   },
 };
 
@@ -72,17 +79,17 @@ export const Layouts: Story = {
   render: () => (
     <Box preset={["stack"]} gap="md">
       <Box preset={["hstack"]} padding="md" backgroundColor="#e3f2fd">
-        <Text as="div">Left</Text>
-        <Text as="div">Right</Text>
+        <Text>Left</Text>
+        <Text>Right</Text>
       </Box>
 
       <Box preset={["center"]} height="100px" backgroundColor="#fef3c7">
-        <Text as="div">Centered</Text>
+        <Text>Centered</Text>
       </Box>
 
       <Box preset={["spaceBetween"]} padding="md" backgroundColor="#e0e7ff">
-        <Text as="div">Start</Text>
-        <Text as="div">End</Text>
+        <Text>Start</Text>
+        <Text>End</Text>
       </Box>
     </Box>
   ),
@@ -92,17 +99,17 @@ export const Presets: Story = {
   render: () => (
     <Box preset={["stack"]} gap="md">
       <Box preset={["card"]}>
-        <Text as="div">Card preset</Text>
+        <Text>Card preset</Text>
       </Box>
 
       <Box preset={["stack", "card"]} gap="sm">
-        <Text as="div">Composed presets</Text>
-        <Text as="div">Stack + Card</Text>
+        <Text>Composed presets</Text>
+        <Text>Stack + Card</Text>
       </Box>
 
       <Box preset={["stack"]} gap="xl" padding="md" backgroundColor="#f0f9ff">
-        <Text as="div">Preset with overrides</Text>
-        <Text as="div">Custom gap and background</Text>
+        <Text>Preset with overrides</Text>
+        <Text>Custom gap and background</Text>
       </Box>
     </Box>
   ),
@@ -112,16 +119,16 @@ export const Polymorphic: Story = {
   render: () => (
     <Box preset={["stack"]} gap="md">
       <Box as="article" preset={["card"]}>
-        <Text as="div">Box as article</Text>
+        <Text>Box as article</Text>
       </Box>
 
       <Box as="section" padding="md" backgroundColor="#e3f2fd">
-        <Text as="div">Box as section</Text>
+        <Text>Box as section</Text>
       </Box>
 
       <Box as="nav" preset={["hstack"]}>
-        <Text as="div">Nav</Text>
-        <Text as="div">Item</Text>
+        <Text>Nav</Text>
+        <Text>Item</Text>
       </Box>
     </Box>
   ),
@@ -139,11 +146,11 @@ export const CustomStyling: Story = {
           } as CSSProperties
         }
       >
-        <Text as="div">CSS variable override</Text>
+        <Text>CSS variable override</Text>
       </Box>
 
       <Box padding="md" backgroundColor="#f8fafc" borderRadius="md">
-        <Text as="div">Prop-based styling</Text>
+        <Text>Prop-based styling</Text>
       </Box>
     </Box>
   ),

--- a/src/components/Svg/Svg.stories.tsx
+++ b/src/components/Svg/Svg.stories.tsx
@@ -226,7 +226,7 @@ export const Responsive: Story = {
       <Svg size={64} responsive color="var(--marduk-color-primary-500)">
         <StarIcon />
       </Svg>
-      <Text as="div" style={{ fontSize: "14px", color: "#666", maxWidth: "400px" }}>
+      <Text style={{ fontSize: "14px", color: "#666", maxWidth: "400px" }}>
         Resize viewport to see responsive scaling at 768px and 1024px breakpoints (custom size with
         responsive prop enabled)
       </Text>


### PR DESCRIPTION
## Description

Cleaned up Text component usage in Storybook stories by removing unnecessary `as='div'` props and improving documentation display.

Changes:
- Removed `as='div'` from Text components in Box.stories.tsx (16 instances) and Svg.stories.tsx (1 instance)
- Updated Box Default story to use Text component wrapper instead of plain string
- Added `children` argType configuration to Box stories for cleaner Storybook docs display

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (no functional changes)

## Testing

- [ ] All tests pass locally (`npm test`)
- [x] Linting passes (`npm run lint`)
- [ ] Type checking passes (`npm run type-check`)
- [ ] Build succeeds (`npm run build`)
- [ ] Added/updated tests for changes

## Component Checklist (if applicable)

N/A - Documentation only changes

## Screenshots (if applicable)

N/A - No visual changes to components, only story code cleanup

## Additional Notes

This is a documentation-only change that improves Storybook story code quality. The Text component's polymorphic `as` prop was being unnecessarily set to 'div' (which is already the default), causing code clutter. All changes verified in Storybook to ensure proper rendering.