### PR TITLE
ci: Add Storybook deployment to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,0 +1,49 @@
+name: Deploy Storybook
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Storybook
+        run: npm run build-storybook
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./storybook-static
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+


### PR DESCRIPTION
## Description

Adds automated Storybook deployment to GitHub Pages using GitHub Actions.

Changes:
- Created `deploy-storybook.yml` workflow that builds and deploys Storybook on every push to main
- Uses GitHub's built-in Pages deployment actions (no tokens required)
- Configured to output to `https://markfoster314.github.io/marduk/`

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (no functional changes)

## Testing

- [ ] All tests pass locally (`npm test`)
- [x] Linting passes (`npm run lint`)
- [ ] Type checking passes (`npm run type-check`)
- [x] Build succeeds (`npm run build`)
- [ ] Added/updated tests for changes

## Component Checklist (if applicable)

N/A - CI/CD infrastructure change

## Screenshots (if applicable)

N/A - Workflow change, no visual components

## Additional Notes

After setup, Storybook will automatically deploy to GitHub Pages on every push to main. The workflow can also be triggered manually from the Actions tab.
