### PR TITLE
docs: Link to component directories instead of README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,15 +176,15 @@ Props always override preset values:
 
 ## Production Ready Features
 
-**Primitives:** [Text](src/components/Text/README.md) | [Box](src/components/Box/README.md)
+**Primitives:** [Text](src/components/Text) | [Box](src/components/Box)
 
 ## In Progress Features
 
-**Primitives:** [Button](src/components/Button/README.md) | [Title](src/components/Title/README.md) | [Svg](src/components/Svg/README.md)
+**Primitives:** [Button](src/components/Button) | [Title](src/components/Title) | [Svg](src/components/Svg)
 
-**Compositions:** [Alert](src/compositions/Alert/README.md) | [LoadingScreen](src/compositions/LoadingScreen/README.md)
+**Compositions:** [Alert](src/compositions/Alert) | [LoadingScreen](src/compositions/LoadingScreen)
 
-[Icons](src/icons/README.md)
+[Icons](src/icons)
 
 ## Development
 


### PR DESCRIPTION
## Description

Updated component links in README to navigate to directory view instead of directly to README files.

Changes:
- Removed `/README.md` suffix from all component links
- Links now show directory listing with README rendered below
- Cleaner URLs and better context for users browsing the repository

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (no functional changes)

## Testing

- [ ] All tests pass locally (`npm test`)
- [ ] Linting passes (`npm run lint`)
- [ ] Type checking passes (`npm run type-check`)
- [ ] Build succeeds (`npm run build`)
- [ ] Added/updated tests for changes

## Component Checklist (if applicable)

N/A - Documentation only

## Screenshots (if applicable)

N/A - Link behavior change

## Additional Notes

GitHub automatically displays README.md content when linking to a directory, so this change improves UX by showing both the directory structure and README content instead of just the README file in isolation.