### PR TITLE
feat: Add preset system to Title and fix Storybook preset controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,11 +177,11 @@ Props always override preset values:
 
 ## Production Ready Features
 
-**Primitives:** [Text](src/components/Text) | [Box](src/components/Box)
+**Primitives:** [Text](src/components/Text) | [Box](src/components/Box) | [Title](src/components/Title)
 
 ## In Progress Features
 
-**Primitives:** [Button](src/components/Button) | [Title](src/components/Title) | [Svg](src/components/Svg)
+**Primitives:** [Button](src/components/Button) | [Svg](src/components/Svg)
 
 **Compositions:** [Alert](src/compositions/Alert) | [LoadingScreen](src/compositions/LoadingScreen)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,9 +7,10 @@ Marduk is a lightweight React component library with zero dependencies, built fo
 ## Current Status
 
 - Version: 0.2.0
-- Test Coverage: 822 tests passing
-- Production-Ready Components: 2 (Box, Text)
+- Test Coverage: 826 tests passing
+- Production-Ready Components: 3 (Box, Text, Title)
 - Total Components: 17
+- v0.3.0 Progress: 1/17 components complete
 
 ## v0.3.0 - Production-Ready Primitives
 
@@ -36,19 +37,11 @@ Marduk is a lightweight React component library with zero dependencies, built fo
   - Focus management
   - Add preset system support
 
-**Title** - Semantic heading component
+**Title** - Semantic heading component ✓ COMPLETE
 
-- Status: WIP → Ready
-- Tasks:
-  - Test all heading levels (h1-h6)
-  - Test all variants (default, primary, secondary, success, warning, danger)
-  - Alignment testing (left, center, right)
-  - Size override testing
-  - Weight override testing
-  - Truncation testing (single-line, multi-line clamp)
-  - Underline styles testing
-  - Dark mode support
-  - Add preset system support
+- Status: WIP → Ready (DONE)
+- Completed in PR #35
+- Added preset system, 125 tests, 98% coverage
 
 **Svg** - Icon wrapper component
 

--- a/src/components/Box/Box.stories.tsx
+++ b/src/components/Box/Box.stories.tsx
@@ -59,8 +59,21 @@ const meta: Meta<typeof Box> = {
       options: ["sm", "md", "lg", "full"],
     },
     preset: {
-      control: "select",
-      options: ["stack", "hstack", "center", "card", "darkCard", "grid2", "grid3", "spaceBetween"],
+      control: { type: "multi-select" },
+      options: [
+        "stack",
+        "hstack",
+        "center",
+        "card",
+        "darkCard",
+        "grid2",
+        "grid3",
+        "spaceBetween",
+        "sidebar",
+        "header",
+        "footer",
+      ],
+      description: "Preset configurations (select multiple)",
     },
   },
 };

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -15,7 +15,7 @@ const meta: Meta<typeof Text> = {
   tags: ["autodocs", "status:ready"],
   argTypes: {
     preset: {
-      control: { type: "select" },
+      control: { type: "multi-select" },
       options: [
         "default",
         "primary",
@@ -32,7 +32,7 @@ const meta: Meta<typeof Text> = {
         "warningDark",
         "mutedDark",
       ],
-      description: "Text preset (replaces variant + darkMode)",
+      description: "Preset configurations (select multiple)",
     },
     size: {
       control: { type: "select" },

--- a/src/components/Title/README.md
+++ b/src/components/Title/README.md
@@ -6,7 +6,7 @@
 
 _"I found you."_
 
-Heading component
+Semantic heading component with preset system
 
 ## Basic Usage
 
@@ -18,7 +18,7 @@ import { Title } from "@markfoster314/marduk";
 
 ## Heading Levels
 
-Use `level` prop for heading hierarchy (h1-h6).
+Use `level` prop for semantic heading hierarchy (h1-h6).
 
 ```tsx
 <Title level={1}>Main Heading</Title>
@@ -26,14 +26,42 @@ Use `level` prop for heading hierarchy (h1-h6).
 <Title level={3}>Subsection</Title>
 ```
 
-## Variants
+## Presets
 
-Current variants: `default`, `primary`, `secondary`, `success`, `warning`, or `danger`.
+Title supports the library's preset system for color variants. See the [main README](../../README.md#presets-system) for detailed documentation on using presets, creating custom presets, and TypeScript support.
+
+### Built-in Title Presets
+
+**Light mode:**
+
+- `default` - Default heading color
+- `primary` - Primary color
+- `secondary` - Secondary color
+- `success` - Success/green
+- `danger` - Danger/red
+- `warning` - Warning/yellow
+- `muted` - Muted/gray
+
+**Dark mode:**
+
+- `defaultDark` - Default heading in dark mode
+- `primaryDark` - Primary color dark mode
+- `secondaryDark` - Secondary color dark mode
+- `successDark` - Success dark mode
+- `dangerDark` - Danger dark mode
+- `warningDark` - Warning dark mode
+- `mutedDark` - Muted dark mode
+
+### Quick Examples
 
 ```tsx
-<Title level={2} variant="primary">Primary Title</Title>
-<Title level={2} variant="success">Success Title</Title>
-<Title level={2} variant="danger">Error Title</Title>
+<Title level={1} preset={["primary"]}>Primary heading</Title>
+
+<Title level={2} preset={["primaryDark"]}>Primary in dark mode</Title>
+
+<Title level={3} preset={["primary"]} size="large" weight="bold">
+  Primary with overrides
+</Title>
 ```
 
 ## Text Alignment
@@ -47,7 +75,7 @@ Current variants: `default`, `primary`, `secondary`, `success`, `warning`, or `d
 
 ## Size & Weight Overrides
 
-Override the default size or weight for custom styling.
+Override default size or weight based on level.
 
 ```tsx
 <Title level={3} size="large">Large H3</Title>
@@ -58,16 +86,14 @@ Override the default size or weight for custom styling.
 
 Truncate long titles with single-line or multi-line clamping.
 
-NOTE: clamp Requires -webkit-line-clamp support (Chrome, Safari, Edge, Firefox 68+)
-
 ```tsx
 <Title level={2} truncate>
   Very long title that gets cut off...
-</Title>;
+</Title>
 
 <Title level={2} clamp maxLines={2}>
   Longer title that wraps to two lines...
-</Title>;
+</Title>
 ```
 
 ## Letter Spacing
@@ -95,107 +121,87 @@ Available styles: `solid`, `double`, `dotted`, `dashed`, `wavy`
 
 ## Polymorphic
 
-Render as anything using the `as` prop while maintaining heading styles.
+Render as any element using `as` prop while maintaining heading styles and accessibility.
 
 ```tsx
-<Title as="div" level={1}>
-  Looks like H1, renders as div
-</Title>;
+<Title level={2} as="div">
+  H2 styling as div with role="heading"
+</Title>
 
-<Title as="a" href="#section" level={2}>
-  Section Link
-</Title>;
-```
-
-Note: Non-heading elements automatically get `role="heading"` and `aria-level` for accessibility.
-
-## Dark Mode
-
-```tsx
-<Title darkMode level={2} variant="primary">
-  Dark Title
+<Title level={1} as="span">
+  H1 styling as span
 </Title>
 ```
+
+Non-heading elements automatically get `role="heading"` and `aria-level` attributes.
 
 ## Custom Colors
 
 ```tsx
-<Title level={1} color="#ff6b6b">
-  Custom Color Title
-</Title>
+<Title level={1} color="#8b5cf6">Custom color</Title>
 
-<Title level={2} color="var(--my-custom-color)">
-  CSS Variable Color
+<Title level={2} color="var(--marduk-color-primary-500)">
+  CSS variable color
 </Title>
 ```
 
 ## Customization
 
-Override CSS variables for custom styling.
+Override default styles using CSS variables:
 
 ```tsx
 <Title
   level={1}
-  style={
-    {
-      "--title-font-size": "4rem",
-      "--title-color": "#ff6b6b",
-      "--title-letter-spacing": "0.1em",
-    } as React.CSSProperties
-  }
+  style={{
+    "--title-font-family": "Georgia, serif",
+    "--title-letter-spacing": "0.05em",
+  }}
 >
-  Custom Title
+  Custom Font
 </Title>
 ```
 
 ### Available CSS Variables
 
-**Base Variables:**
-
-- `--title-color`
-- `--title-font-family`
-- `--title-font-size`
-- `--title-font-weight`
-- `--title-line-height`
-- `--title-letter-spacing`
-- `--title-text-transform`
-- `--title-margin-top`
-- `--title-margin-bottom`
-
-**Underline Variables:**
-
-- `--title-underline-thickness`
-- `--title-underline-offset`
-- `--title-underline-double-thickness`
-
-**High Contrast Variables:**
-
-- `--title-high-contrast-border-width`
-- `--title-high-contrast-padding`
-- `--title-high-contrast-underline-thickness`
-- `--title-high-contrast-underline-offset`
-- `--title-high-contrast-double-thickness`
-- `--title-high-contrast-link-thickness`
-- `--title-high-contrast-link-offset`
+```css
+--title-color
+--title-font-family
+--title-font-size
+--title-font-weight
+--title-line-height
+--title-letter-spacing
+--title-text-transform
+--title-margin-top
+--title-margin-bottom
+--title-underline-thickness
+--title-underline-offset
+--title-underline-double-thickness
+--marduk-title-custom-color
+--title-max-lines
+```
 
 ## Props
 
-| Prop             | Type                                                              | Default   | Description                          |
-| ---------------- | ----------------------------------------------------------------- | --------- | ------------------------------------ |
-| `level`          | `1 \| 2 \| 3 \| 4 \| 5 \| 6`                                      | `1`       | Semantic heading level               |
-| `variant`        | `default \| primary \| secondary \| success \| warning \| danger` | `default` | Color variant                        |
-| `align`          | `left \| center \| right`                                         | `left`    | Text alignment                       |
-| `size`           | `small \| medium \| large`                                        | -         | Size override (optional)             |
-| `weight`         | `normal \| medium \| semibold \| bold`                            | -         | Weight override (optional)           |
-| `truncate`       | `boolean`                                                         | `false`   | Single-line truncation with ellipsis |
-| `clamp`          | `boolean`                                                         | `false`   | Multi-line truncation                |
-| `maxLines`       | `number`                                                          | `2`       | Max lines when clamping              |
-| `spacing`        | `tight \| normal \| wide`                                         | -         | Letter spacing preset                |
-| `underlined`     | `boolean`                                                         | `false`   | Add underline decoration             |
-| `underlineStyle` | `solid \| double \| dotted \| dashed \| wavy`                     | `solid`   | Underline style                      |
-| `darkMode`       | `boolean`                                                         | `false`   | Dark mode styling                    |
-| `color`          | `string`                                                          | -         | Custom color (hex, rgb, CSS var)     |
-| `as`             | `ElementType`                                                     | (dynamic) | Render as different element          |
+```typescript
+interface TitleProps {
+  children: ReactNode;
+  as?: ElementType; // h1-h6, div, span, p, etc.
+  preset?: string[]; // Preset configurations
+  level?: 1 | 2 | 3 | 4 | 5 | 6; // Heading level (default: 1)
+  align?: "left" | "center" | "right"; // Text alignment
+  size?: "small" | "medium" | "large"; // Size override
+  weight?: "normal" | "medium" | "semibold" | "bold"; // Weight override
+  color?: string; // Custom color
+  truncate?: boolean; // Single-line truncation
+  clamp?: boolean; // Multi-line truncation
+  maxLines?: number; // Max lines for clamp (default: 2)
+  spacing?: "tight" | "normal" | "wide"; // Letter spacing
+  underlined?: boolean; // Add underline
+  underlineStyle?: "solid" | "double" | "dotted" | "dashed" | "wavy";
+  className?: string;
+  style?: CSSProperties;
+}
+```
 
 Plus all standard heading/element props.
 
@@ -210,27 +216,27 @@ Plus all standard heading/element props.
 
 ## Responsive Design
 
-Like the rest of the project, the title component handles these three screen sizes responsiveness automatically.
+Titles scale automatically across three breakpoints:
 
 - **Mobile** (0-767px): Base sizes
 - **Tablet** (768px+): Larger sizes
 - **Desktop** (1024px+): Largest sizes
 
-No configuration needed
+No configuration needed.
 
 ## Testing
 
-Data attributes are included for E2E testing:
+Data attributes are included for testing:
 
 ```tsx
-<Title level={2} variant="primary" align="center" truncate />
+<Title level={2} preset={["primary"]} align="center" truncate />
 // data-level="2"
-// data-variant="primary"
+// data-preset="primary"
 // data-align="center"
 // data-truncate="true"
 ```
 
-Available attributes: `data-level`, `data-variant`, `data-align`, `data-size`, `data-weight`, `data-dark-mode`, `data-custom-color`, `data-truncate`, `data-clamp`, `data-max-lines`, `data-spacing`, `data-underlined`, `data-underline-style`
+Available attributes: `data-preset`, `data-level`, `data-align`, `data-size`, `data-weight`, `data-custom-color`, `data-truncate`, `data-clamp`, `data-max-lines`, `data-spacing`, `data-underlined`, `data-underline-style`
 
 ---
 

--- a/src/components/Title/Title.stories.tsx
+++ b/src/components/Title/Title.stories.tsx
@@ -10,11 +10,31 @@ const meta: Meta<typeof Title> = {
   parameters: {
     layout: "centered",
     docs: {
-      subtitle: STORYBOOK_STATUS.WIP,
+      subtitle: STORYBOOK_STATUS.READY,
     },
   },
-  tags: ["autodocs", "status:wip"],
+  tags: ["autodocs", "status:ready"],
   argTypes: {
+    preset: {
+      control: { type: "multi-select" },
+      options: [
+        "default",
+        "primary",
+        "secondary",
+        "success",
+        "danger",
+        "warning",
+        "muted",
+        "defaultDark",
+        "primaryDark",
+        "secondaryDark",
+        "successDark",
+        "dangerDark",
+        "warningDark",
+        "mutedDark",
+      ],
+      description: "Preset configurations (select multiple)",
+    },
     as: {
       control: { type: "select" },
       options: ["h1", "h2", "h3", "h4", "h5", "h6", "div", "span", "p"],
@@ -24,11 +44,6 @@ const meta: Meta<typeof Title> = {
       control: { type: "select" },
       options: [1, 2, 3, 4, 5, 6],
       description: "Heading level (h1-h6)",
-    },
-    variant: {
-      control: { type: "select" },
-      options: ["default", "primary", "secondary", "success", "warning", "danger"],
-      description: "Color variant",
     },
     align: {
       control: { type: "select" },
@@ -44,10 +59,6 @@ const meta: Meta<typeof Title> = {
       control: { type: "select" },
       options: ["normal", "medium", "semibold", "bold"],
       description: "Font weight override",
-    },
-    darkMode: {
-      control: { type: "boolean" },
-      description: "Enable dark mode styling",
     },
     color: {
       control: { type: "color" },
@@ -105,26 +116,24 @@ export const AllLevels: Story = {
   ),
 };
 
-export const Variants: Story = {
+export const Presets: Story = {
   render: () => (
     <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
-      <Title level={2} variant="default">
-        Default variant
+      <Title level={2}>Default preset</Title>
+      <Title level={2} preset={["primary"]}>
+        Primary preset
       </Title>
-      <Title level={2} variant="primary">
-        Primary variant
+      <Title level={2} preset={["secondary"]}>
+        Secondary preset
       </Title>
-      <Title level={2} variant="secondary">
-        Secondary variant
+      <Title level={2} preset={["success"]}>
+        Success preset
       </Title>
-      <Title level={2} variant="success">
-        Success variant
+      <Title level={2} preset={["warning"]}>
+        Warning preset
       </Title>
-      <Title level={2} variant="warning">
-        Warning variant
-      </Title>
-      <Title level={2} variant="danger">
-        Danger variant
+      <Title level={2} preset={["danger"]}>
+        Danger preset
       </Title>
     </div>
   ),
@@ -234,13 +243,13 @@ export const DarkMode: Story = {
         gap: "16px",
       }}
     >
-      <Title level={2} darkMode variant="primary">
+      <Title level={2} preset={["primaryDark"]}>
         Primary title in dark mode
       </Title>
-      <Title level={2} darkMode variant="success">
+      <Title level={2} preset={["successDark"]}>
         Success title in dark mode
       </Title>
-      <Title level={2} darkMode variant="danger">
+      <Title level={2} preset={["dangerDark"]}>
         Danger title in dark mode
       </Title>
     </div>
@@ -293,7 +302,7 @@ export const CustomStyling: Story = {
           } as React.CSSProperties
         }
         underlined
-        variant="primary"
+        preset={["primary"]}
       >
         Custom underline via CSS variables
       </Title>

--- a/src/components/Title/Title.test.tsx
+++ b/src/components/Title/Title.test.tsx
@@ -1,6 +1,13 @@
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { Title } from "./Title";
+import {
+  defineTitlePresets,
+  getPreset,
+  getAllPresets,
+  resetCustomPresets,
+  builtInPresets,
+} from "./presets";
 
 describe("Title", () => {
   describe("Rendering", () => {
@@ -54,34 +61,31 @@ describe("Title", () => {
   });
 
   describe("Variants", () => {
-    it("applies default variant by default", () => {
+    it("renders without preset by default", () => {
       render(<Title>Test</Title>);
-      expect(screen.getByText("Test")).toHaveClass("marduk-title--variant-default");
+      const element = screen.getByText("Test");
+      expect(element).toBeInTheDocument();
+      expect(element.getAttribute("data-preset")).toBeNull();
     });
 
-    it("applies primary variant class", () => {
-      render(<Title variant="primary">Test</Title>);
-      expect(screen.getByText("Test")).toHaveClass("marduk-title--variant-primary");
+    it("applies primary preset color", () => {
+      render(<Title preset={["primary"]}>Test</Title>);
+      const element = screen.getByText("Test");
+      expect(element).toBeInTheDocument();
+      expect(element.getAttribute("data-preset")).toBe("primary");
     });
 
-    it("applies secondary variant class", () => {
-      render(<Title variant="secondary">Test</Title>);
-      expect(screen.getByText("Test")).toHaveClass("marduk-title--variant-secondary");
+    it("applies secondary preset color", () => {
+      render(<Title preset={["secondary"]}>Test</Title>);
+      const element = screen.getByText("Test");
+      expect(element).toBeInTheDocument();
+      expect(element.getAttribute("data-preset")).toBe("secondary");
     });
 
-    it("applies success variant class", () => {
-      render(<Title variant="success">Test</Title>);
-      expect(screen.getByText("Test")).toHaveClass("marduk-title--variant-success");
-    });
-
-    it("applies warning variant class", () => {
-      render(<Title variant="warning">Test</Title>);
-      expect(screen.getByText("Test")).toHaveClass("marduk-title--variant-warning");
-    });
-
-    it("applies danger variant class", () => {
-      render(<Title variant="danger">Test</Title>);
-      expect(screen.getByText("Test")).toHaveClass("marduk-title--variant-danger");
+    it("applies multiple presets", () => {
+      render(<Title preset={["primary", "muted"]}>Test</Title>);
+      const element = screen.getByText("Test");
+      expect(element.getAttribute("data-preset")).toBe("primary,muted");
     });
   });
 
@@ -195,9 +199,9 @@ describe("Title", () => {
     });
 
     it("applies marduk-title class for high contrast targeting", () => {
-      render(<Title variant="primary">Test</Title>);
+      render(<Title preset={["primary"]}>Test</Title>);
       expect(screen.getByText("Test")).toHaveClass("marduk-title");
-      expect(screen.getByText("Test")).toHaveClass("marduk-title--variant-primary");
+      expect(screen.getByText("Test")).toHaveAttribute("data-preset", "primary");
     });
 
     it("renders with href for link testing", () => {
@@ -222,41 +226,23 @@ describe("Title", () => {
     });
   });
 
-  describe("Dark Mode", () => {
-    it("does not apply dark mode class by default", () => {
-      render(<Title>Test</Title>);
+  describe("Dark Mode Presets", () => {
+    it("applies primaryDark preset", () => {
+      render(<Title preset={["primaryDark"]}>Test</Title>);
       const element = screen.getByText("Test");
-      expect(element).not.toHaveClass("marduk-title--dark");
+      expect(element).toHaveAttribute("data-preset", "primaryDark");
     });
 
-    it("applies dark mode class when darkMode is true", () => {
-      render(<Title darkMode>Test</Title>);
-      expect(screen.getByText("Test")).toHaveClass("marduk-title--dark");
+    it("applies successDark preset", () => {
+      render(<Title preset={["successDark"]}>Test</Title>);
+      const element = screen.getByText("Test");
+      expect(element).toHaveAttribute("data-preset", "successDark");
     });
 
-    it("does not apply dark mode class when darkMode is false", () => {
-      render(<Title darkMode={false}>Test</Title>);
-      expect(screen.getByText("Test")).not.toHaveClass("marduk-title--dark");
-    });
-
-    it("works with all variants in dark mode", () => {
-      const { rerender } = render(
-        <Title darkMode variant="primary">
-          Test
-        </Title>,
-      );
-      let element = screen.getByText("Test");
-      expect(element).toHaveClass("marduk-title--dark");
-      expect(element).toHaveClass("marduk-title--variant-primary");
-
-      rerender(
-        <Title darkMode variant="success">
-          Test
-        </Title>,
-      );
-      element = screen.getByText("Test");
-      expect(element).toHaveClass("marduk-title--dark");
-      expect(element).toHaveClass("marduk-title--variant-success");
+    it("applies dangerDark preset", () => {
+      render(<Title preset={["dangerDark"]}>Test</Title>);
+      const element = screen.getByText("Test");
+      expect(element).toHaveAttribute("data-preset", "dangerDark");
     });
   });
 
@@ -298,14 +284,14 @@ describe("Title", () => {
       });
     });
 
-    it("applies custom color class alongside variant class", () => {
+    it("applies custom color with preset", () => {
       render(
-        <Title variant="primary" color="#00ff00">
+        <Title preset={["primary"]} color="#00ff00">
           Test
         </Title>,
       );
       const title = screen.getByText("Test");
-      expect(title).toHaveClass("marduk-title--variant-primary");
+      expect(title).toHaveAttribute("data-preset", "primary");
       expect(title).toHaveClass("marduk-title--custom-color");
       expect(title).toHaveStyle({ "--marduk-title-custom-color": "#00ff00" });
     });
@@ -352,28 +338,27 @@ describe("Title", () => {
   describe("Combined Props", () => {
     it("applies multiple prop classes together", () => {
       render(
-        <Title level={3} variant="primary" align="center" size="large" weight="bold">
+        <Title level={3} preset={["primary"]} align="center" size="large" weight="bold">
           Combined
         </Title>,
       );
       const element = screen.getByText("Combined");
       expect(element).toHaveClass("marduk-title--level-3");
-      expect(element).toHaveClass("marduk-title--variant-primary");
+      expect(element).toHaveAttribute("data-preset", "primary");
       expect(element).toHaveClass("marduk-title--align-center");
       expect(element).toHaveClass("marduk-title--size-large");
       expect(element).toHaveClass("marduk-title--weight-bold");
     });
 
-    it("applies dark mode with other props", () => {
+    it("applies dark preset with other props", () => {
       render(
-        <Title level={2} variant="primary" darkMode>
+        <Title level={2} preset={["primaryDark"]}>
           Dark Title
         </Title>,
       );
       const element = screen.getByText("Dark Title");
       expect(element).toHaveClass("marduk-title--level-2");
-      expect(element).toHaveClass("marduk-title--variant-primary");
-      expect(element).toHaveClass("marduk-title--dark");
+      expect(element).toHaveAttribute("data-preset", "primaryDark");
     });
   });
 
@@ -383,9 +368,9 @@ describe("Title", () => {
       expect(screen.getByText("Test")).toHaveAttribute("data-level", "3");
     });
 
-    it("applies data-variant attribute", () => {
-      render(<Title variant="primary">Test</Title>);
-      expect(screen.getByText("Test")).toHaveAttribute("data-variant", "primary");
+    it("applies data-preset attribute", () => {
+      render(<Title preset={["primary"]}>Test</Title>);
+      expect(screen.getByText("Test")).toHaveAttribute("data-preset", "primary");
     });
 
     it("applies data-align attribute", () => {
@@ -413,14 +398,9 @@ describe("Title", () => {
       expect(screen.getByText("Test")).not.toHaveAttribute("data-weight");
     });
 
-    it("applies data-dark-mode when darkMode is true", () => {
-      render(<Title darkMode>Test</Title>);
-      expect(screen.getByText("Test")).toHaveAttribute("data-dark-mode", "true");
-    });
-
-    it("does not apply data-dark-mode when darkMode is false", () => {
-      render(<Title darkMode={false}>Test</Title>);
-      expect(screen.getByText("Test")).not.toHaveAttribute("data-dark-mode");
+    it("does not apply data-preset when no preset is provided", () => {
+      render(<Title>Test</Title>);
+      expect(screen.getByText("Test")).not.toHaveAttribute("data-preset");
     });
 
     it("applies data-custom-color when color prop is provided", () => {
@@ -437,11 +417,10 @@ describe("Title", () => {
       render(
         <Title
           level={2}
-          variant="success"
+          preset={["success"]}
           align="right"
           size="small"
           weight="semibold"
-          darkMode
           color="#00ff00"
         >
           Full Test
@@ -449,11 +428,10 @@ describe("Title", () => {
       );
       const element = screen.getByText("Full Test");
       expect(element).toHaveAttribute("data-level", "2");
-      expect(element).toHaveAttribute("data-variant", "success");
+      expect(element).toHaveAttribute("data-preset", "success");
       expect(element).toHaveAttribute("data-align", "right");
       expect(element).toHaveAttribute("data-size", "small");
       expect(element).toHaveAttribute("data-weight", "semibold");
-      expect(element).toHaveAttribute("data-dark-mode", "true");
       expect(element).toHaveAttribute("data-custom-color", "true");
     });
 
@@ -461,7 +439,6 @@ describe("Title", () => {
       render(<Title>Default</Title>);
       const element = screen.getByText("Default");
       expect(element).toHaveAttribute("data-level", "1");
-      expect(element).toHaveAttribute("data-variant", "default");
       expect(element).toHaveAttribute("data-align", "left");
     });
   });
@@ -529,14 +506,14 @@ describe("Title", () => {
 
     it("applies all styling classes when using as prop", () => {
       render(
-        <Title as="div" level={2} variant="primary" align="center" size="large">
+        <Title as="div" level={2} preset={["primary"]} align="center" size="large">
           Styled Div
         </Title>,
       );
       const element = screen.getByText("Styled Div");
       expect(element).toHaveClass("marduk-title");
       expect(element).toHaveClass("marduk-title--level-2");
-      expect(element).toHaveClass("marduk-title--variant-primary");
+      expect(element).toHaveAttribute("data-preset", "primary");
       expect(element).toHaveClass("marduk-title--align-center");
       expect(element).toHaveClass("marduk-title--size-large");
     });
@@ -562,15 +539,14 @@ describe("Title", () => {
       expect(element).toHaveAttribute("id", "test-id");
     });
 
-    it("works with dark mode when using as prop", () => {
+    it("works with dark preset when using as prop", () => {
       render(
-        <Title as="span" darkMode>
+        <Title as="span" preset={["primaryDark"]}>
           Dark Span
         </Title>,
       );
       const element = screen.getByText("Dark Span");
-      expect(element).toHaveClass("marduk-title--dark");
-      expect(element).toHaveAttribute("data-dark-mode", "true");
+      expect(element).toHaveAttribute("data-preset", "primaryDark");
     });
 
     it("works with custom color when using as prop", () => {
@@ -719,15 +695,15 @@ describe("Title", () => {
       expect(screen.getByText("Normal")).not.toHaveAttribute("data-max-lines");
     });
 
-    it("works with all variants when truncated", () => {
+    it("works with presets when truncated", () => {
       render(
-        <Title truncate variant="primary">
+        <Title truncate preset={["primary"]}>
           Truncated Primary
         </Title>,
       );
       const element = screen.getByText("Truncated Primary");
       expect(element).toHaveClass("marduk-title--truncate");
-      expect(element).toHaveClass("marduk-title--variant-primary");
+      expect(element).toHaveAttribute("data-preset", "primary");
     });
 
     it("works with all levels when clamped", () => {
@@ -753,15 +729,15 @@ describe("Title", () => {
       expect(element).toHaveClass("marduk-title--truncate");
     });
 
-    it("works with dark mode", () => {
+    it("works with dark preset", () => {
       render(
-        <Title clamp maxLines={2} darkMode>
+        <Title clamp maxLines={2} preset={["primaryDark"]}>
           Dark Clamped
         </Title>,
       );
       const element = screen.getByText("Dark Clamped");
       expect(element).toHaveClass("marduk-title--clamp");
-      expect(element).toHaveClass("marduk-title--dark");
+      expect(element).toHaveAttribute("data-preset", "primaryDark");
     });
   });
 
@@ -797,15 +773,15 @@ describe("Title", () => {
       expect(screen.getByText("Test")).not.toHaveAttribute("data-spacing");
     });
 
-    it("works with all variants", () => {
+    it("works with presets", () => {
       render(
-        <Title spacing="wide" variant="primary">
+        <Title spacing="wide" preset={["primary"]}>
           Wide Primary
         </Title>,
       );
       const element = screen.getByText("Wide Primary");
       expect(element).toHaveClass("marduk-title--spacing-wide");
-      expect(element).toHaveClass("marduk-title--variant-primary");
+      expect(element).toHaveAttribute("data-preset", "primary");
     });
 
     it("works with polymorphic rendering", () => {
@@ -909,16 +885,16 @@ describe("Title", () => {
       expect(element).not.toHaveClass("marduk-title--underline-wavy");
     });
 
-    it("works with all variants", () => {
+    it("works with presets", () => {
       render(
-        <Title underlined underlineStyle="wavy" variant="primary">
+        <Title underlined underlineStyle="wavy" preset={["primary"]}>
           Underlined Primary
         </Title>,
       );
       const element = screen.getByText("Underlined Primary");
       expect(element).toHaveClass("marduk-title--underlined");
       expect(element).toHaveClass("marduk-title--underline-wavy");
-      expect(element).toHaveClass("marduk-title--variant-primary");
+      expect(element).toHaveAttribute("data-preset", "primary");
     });
 
     it("works with custom colors", () => {
@@ -974,7 +950,7 @@ describe("Title", () => {
       render(
         <Title
           level={2}
-          variant="primary"
+          preset={["primary"]}
           spacing="wide"
           underlined
           underlineStyle="wavy"
@@ -986,12 +962,80 @@ describe("Title", () => {
       );
       const element = screen.getByText("All Features");
       expect(element).toHaveClass("marduk-title--level-2");
-      expect(element).toHaveClass("marduk-title--variant-primary");
+      expect(element).toHaveAttribute("data-preset", "primary");
       expect(element).toHaveClass("marduk-title--spacing-wide");
       expect(element).toHaveClass("marduk-title--underlined");
       expect(element).toHaveClass("marduk-title--underline-wavy");
       expect(element).toHaveClass("marduk-title--weight-bold");
       expect(element).toHaveClass("marduk-title--size-large");
+    });
+  });
+
+  describe("Preset System", () => {
+    beforeEach(() => {
+      resetCustomPresets();
+    });
+
+    it("has built-in presets", () => {
+      expect(builtInPresets.primary).toBeDefined();
+      expect(builtInPresets.secondary).toBeDefined();
+      expect(builtInPresets.success).toBeDefined();
+    });
+
+    it("getPreset returns built-in preset", () => {
+      const preset = getPreset("primary");
+      expect(preset).toBeDefined();
+      expect(preset?.style?.color).toBe("var(--marduk-color-primary-500)");
+    });
+
+    it("getPreset returns undefined for non-existent preset", () => {
+      const preset = getPreset("nonexistent");
+      expect(preset).toBeUndefined();
+    });
+
+    it("defineTitlePresets adds custom preset", () => {
+      defineTitlePresets({
+        custom: { size: "large", weight: "bold" },
+      });
+      const preset = getPreset("custom");
+      expect(preset).toEqual({ size: "large", weight: "bold" });
+    });
+
+    it("getAllPresets returns all presets", () => {
+      defineTitlePresets({
+        custom: { size: "large" },
+      });
+      const allPresets = getAllPresets();
+      expect(allPresets.primary).toBeDefined();
+      expect(allPresets.custom).toBeDefined();
+    });
+
+    it("resetCustomPresets clears custom presets", () => {
+      defineTitlePresets({
+        custom: { size: "large" },
+      });
+      expect(getPreset("custom")).toBeDefined();
+      resetCustomPresets();
+      expect(getPreset("custom")).toBeUndefined();
+    });
+
+    it("custom preset overrides built-in with same name", () => {
+      defineTitlePresets({
+        primary: { size: "large" },
+      });
+      const preset = getPreset("primary");
+      expect(preset).toEqual({ size: "large" });
+    });
+
+    it("applies custom preset in component", () => {
+      defineTitlePresets({
+        hero: { size: "large", weight: "bold", align: "center" },
+      });
+      render(<Title preset={["hero"]}>Hero Title</Title>);
+      const element = screen.getByText("Hero Title");
+      expect(element).toHaveClass("marduk-title--size-large");
+      expect(element).toHaveClass("marduk-title--weight-bold");
+      expect(element).toHaveClass("marduk-title--align-center");
     });
   });
 });

--- a/src/components/Title/Title.types.ts
+++ b/src/components/Title/Title.types.ts
@@ -1,3 +1,1 @@
-export type TitleVariant = "default" | "primary" | "secondary" | "success" | "warning" | "danger";
-
 export type TitleSize = "small" | "medium" | "large";

--- a/src/components/Title/augmentation.ts
+++ b/src/components/Title/augmentation.ts
@@ -1,0 +1,20 @@
+import type { TitlePresetConfig } from "./presets";
+
+declare module "@markfoster314/marduk" {
+  interface TitlePresets {
+    default: TitlePresetConfig;
+    primary: TitlePresetConfig;
+    secondary: TitlePresetConfig;
+    success: TitlePresetConfig;
+    danger: TitlePresetConfig;
+    warning: TitlePresetConfig;
+    muted: TitlePresetConfig;
+    defaultDark: TitlePresetConfig;
+    primaryDark: TitlePresetConfig;
+    secondaryDark: TitlePresetConfig;
+    successDark: TitlePresetConfig;
+    dangerDark: TitlePresetConfig;
+    warningDark: TitlePresetConfig;
+    mutedDark: TitlePresetConfig;
+  }
+}

--- a/src/components/Title/presets.ts
+++ b/src/components/Title/presets.ts
@@ -1,0 +1,112 @@
+import type { TitleProps } from "./Title";
+
+export type TitlePresetConfig = Partial<
+  Omit<TitleProps<"h1">, "children" | "as" | "className" | "preset">
+>;
+
+export interface TitlePresets {
+  default: TitlePresetConfig;
+  primary: TitlePresetConfig;
+  secondary: TitlePresetConfig;
+  success: TitlePresetConfig;
+  danger: TitlePresetConfig;
+  warning: TitlePresetConfig;
+  muted: TitlePresetConfig;
+  defaultDark: TitlePresetConfig;
+  primaryDark: TitlePresetConfig;
+  secondaryDark: TitlePresetConfig;
+  successDark: TitlePresetConfig;
+  dangerDark: TitlePresetConfig;
+  warningDark: TitlePresetConfig;
+  mutedDark: TitlePresetConfig;
+}
+
+let customPresets: Record<string, TitlePresetConfig> = {};
+
+export const builtInPresets: TitlePresets = {
+  default: {},
+  primary: {
+    style: {
+      color: "var(--marduk-color-primary-500)",
+    },
+  },
+  secondary: {
+    style: {
+      color: "var(--marduk-color-gray-600)",
+    },
+  },
+  success: {
+    style: {
+      color: "var(--marduk-color-success-500)",
+    },
+  },
+  danger: {
+    style: {
+      color: "var(--marduk-color-error-400)",
+    },
+  },
+  warning: {
+    style: {
+      color: "var(--marduk-color-warning-500)",
+    },
+  },
+  muted: {
+    style: {
+      color: "var(--marduk-color-gray-500)",
+    },
+  },
+  defaultDark: {
+    style: {
+      color: "var(--marduk-color-dark-text-primary)",
+    },
+  },
+  primaryDark: {
+    style: {
+      color: "var(--marduk-color-primary-300)",
+    },
+  },
+  secondaryDark: {
+    style: {
+      color: "var(--marduk-color-dark-text-secondary)",
+    },
+  },
+  successDark: {
+    style: {
+      color: "var(--marduk-color-success-300)",
+    },
+  },
+  dangerDark: {
+    style: {
+      color: "var(--marduk-color-error-200)",
+    },
+  },
+  warningDark: {
+    style: {
+      color: "var(--marduk-color-warning-200)",
+    },
+  },
+  mutedDark: {
+    style: {
+      color: "var(--marduk-color-dark-text-tertiary)",
+    },
+  },
+};
+
+export function defineTitlePresets(presets: Record<string, TitlePresetConfig>): void {
+  customPresets = { ...customPresets, ...presets };
+}
+
+export function getPreset(name: string): TitlePresetConfig | undefined {
+  if (customPresets[name]) {
+    return customPresets[name];
+  }
+  return builtInPresets[name as keyof TitlePresets];
+}
+
+export function getAllPresets(): Record<string, TitlePresetConfig> {
+  return { ...builtInPresets, ...customPresets };
+}
+
+export function resetCustomPresets(): void {
+  customPresets = {};
+}

--- a/src/compositions/Alert/Alert.test.tsx
+++ b/src/compositions/Alert/Alert.test.tsx
@@ -238,4 +238,86 @@ describe("Alert", () => {
       expect(screen.getByLabelText("Close alert")).toBeInTheDocument();
     });
   });
+
+  describe("Title Presets", () => {
+    it("uses primary preset for info variant", () => {
+      render(
+        <Alert variant="info" title="Info Title">
+          Message
+        </Alert>,
+      );
+      const title = screen.getByText("Info Title");
+      expect(title).toHaveAttribute("data-preset", "primary");
+    });
+
+    it("uses success preset for success variant", () => {
+      render(
+        <Alert variant="success" title="Success Title">
+          Message
+        </Alert>,
+      );
+      const title = screen.getByText("Success Title");
+      expect(title).toHaveAttribute("data-preset", "success");
+    });
+
+    it("uses warning preset for warning variant", () => {
+      render(
+        <Alert variant="warning" title="Warning Title">
+          Message
+        </Alert>,
+      );
+      const title = screen.getByText("Warning Title");
+      expect(title).toHaveAttribute("data-preset", "warning");
+    });
+
+    it("uses danger preset for error variant", () => {
+      render(
+        <Alert variant="error" title="Error Title">
+          Message
+        </Alert>,
+      );
+      const title = screen.getByText("Error Title");
+      expect(title).toHaveAttribute("data-preset", "danger");
+    });
+
+    it("uses dark presets when darkMode is true", () => {
+      render(
+        <Alert variant="info" title="Dark Title" darkMode>
+          Message
+        </Alert>,
+      );
+      const title = screen.getByText("Dark Title");
+      expect(title).toHaveAttribute("data-preset", "primaryDark");
+    });
+
+    it("uses dark success preset", () => {
+      render(
+        <Alert variant="success" title="Dark Success" darkMode>
+          Message
+        </Alert>,
+      );
+      const title = screen.getByText("Dark Success");
+      expect(title).toHaveAttribute("data-preset", "successDark");
+    });
+
+    it("uses dark warning preset", () => {
+      render(
+        <Alert variant="warning" title="Dark Warning" darkMode>
+          Message
+        </Alert>,
+      );
+      const title = screen.getByText("Dark Warning");
+      expect(title).toHaveAttribute("data-preset", "warningDark");
+    });
+
+    it("uses dark danger preset for error variant", () => {
+      render(
+        <Alert variant="error" title="Dark Error" darkMode>
+          Message
+        </Alert>,
+      );
+      const title = screen.getByText("Dark Error");
+      expect(title).toHaveAttribute("data-preset", "dangerDark");
+    });
+  });
 });

--- a/src/compositions/Alert/Alert.tsx
+++ b/src/compositions/Alert/Alert.tsx
@@ -88,21 +88,22 @@ export const Alert = ({
     return darkMode ? `${basePreset}Dark` : basePreset;
   };
 
-  // This is temporary for when we migrate to the new title component
-  const getTitleVariant = () => {
-    if (darkMode) {
-      return "secondary";
-    }
+  const getTitlePreset = () => {
+    let basePreset = "";
     switch (variant) {
       case "success":
-        return "success";
+        basePreset = "success";
+        break;
       case "warning":
-        return "warning";
+        basePreset = "warning";
+        break;
       case "error":
-        return "danger";
+        basePreset = "danger";
+        break;
       default:
-        return "primary";
+        basePreset = "primary";
     }
+    return darkMode ? `${basePreset}Dark` : basePreset;
   };
 
   const getButtonVariant = () => {
@@ -132,12 +133,7 @@ export const Alert = ({
       <div className="marduk-alert-icon">{icons[variant]}</div>
       <div className="marduk-alert-content">
         {title && (
-          <Title
-            level={6}
-            darkMode={darkMode}
-            variant={getTitleVariant()}
-            className="marduk-alert-title"
-          >
+          <Title level={6} preset={[getTitlePreset()]} className="marduk-alert-title">
             {title}
           </Title>
         )}

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,13 @@ export type { TextPresetConfig, TextPresets } from "./components/Text/presets";
 
 export { Title } from "./components/Title/Title";
 export type { TitleProps } from "./components/Title/Title";
-export type { TitleVariant, TitleSize } from "./components/Title/Title.types";
+export {
+  defineTitlePresets,
+  getAllPresets as getAllTitlePresets,
+  resetCustomPresets as resetTitleCustomPresets,
+} from "./components/Title/presets";
+export type { TitlePresetConfig, TitlePresets } from "./components/Title/presets";
+export type { TitleSize } from "./components/Title/Title.types";
 
 export { Svg } from "./components/Svg/Svg";
 export type { SvgProps } from "./components/Svg/Svg";


### PR DESCRIPTION
## Description

Migrates Title component to preset system and fixes Storybook preset controls for Box, Text, and Title.

Changes:
- Add preset system to Title component (matches Text pattern)
- Remove variant and darkMode props from Title (breaking change)
- Fix Storybook preset controls (multi-select for array support)
- Update Alert composition to use Title presets
- Title component now ready (98% test coverage, 125 tests)
- Update main README: Title moved to Ready section

Closes #12 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (no functional changes)

## Testing

- [x] All tests pass locally (`npm test`)
- [x] Linting passes (`npm run lint`)
- [x] Type checking passes (`npm run type-check`)
- [X ] Build succeeds (`npm run build`)
- [x] Added/updated tests for changes

## Component Checklist (if applicable)

- [x] Component follows existing patterns
- [x] Includes TypeScript types
- [x] Has tests with good coverage
- [x] Has Storybook story
- [x] CSS uses design tokens/variables
- [x] Accessibility considered (ARIA, keyboard navigation)
- [x] Works in dark mode (if applicable)

## Screenshots (if applicable)

N/A - Test in Storybook

## Additional Notes

**Breaking change for Title users:**
// Old
<Title variant="primary" darkMode>Hello</Title>

// New
<Title preset={["primaryDark"]}>Hello</Title>

Storybook preset controls now support multiple selection for Box, Text, and Title components.